### PR TITLE
add nothing and a random sleep

### DIFF
--- a/character.py
+++ b/character.py
@@ -33,6 +33,12 @@ class move():
         Makes the player jump.
         '''
         pyautogui.press("space")
+
+    def nothing():
+        '''
+        Makes the character do nothing.
+        '''
+
     
     def stop(movement: str) -> None:
         '''

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from tqdm import tqdm
 import time
 import random
 
-movements = [character.move.left, character.move.right, character.move.forward, character.move.backward]
+movements = [character.move.left, character.move.right, character.move.forward, character.move.backward, character.move.nothing]
 
 def single_movement():
     previous_movement = ""
@@ -18,7 +18,7 @@ def single_movement():
         random_key()
 
         for x in tqdm(range(random.randint(3, 10))):
-            time.sleep(1)
+            time.sleep(random.random())
             if random.randint(1, 6) == 1:
                 character.move.jump()
         


### PR DESCRIPTION
When running auto macros, it's a good idea to add in the concept of 'nothing' and not use ints whenever possible.

Basically, you want to do whatever you can to make it harder to detect. If I look at logs and see that someone is moving non stop for 3 hours, I assume they are afking.

If I look at logs and see that someone is moving in a random direction every 3-10 seconds, i assume they are using a macro. Adding in randomness makes it a lot harder to detect